### PR TITLE
fix: Link application.css in app/assets/config/manifest.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link application.css


### PR DESCRIPTION
Fix the following error

```
$ APPMAP=false DISABLE_SPRING=true GEM_HOME=gems bundle exec rails test

ERROR["test_should_get_new", #<Minitest::Reporters::Suite:0x0000560498fa92e8 @name="SessionsControllerTest">, 2.1409459663555026]
 test_should_get_new#SessionsControllerTest (2.14s)
ActionView::Template::Error:         ActionView::Template::Error: Asset `application.css` was not declared to be precompiled in production.
        Declare links to your assets in `app/assets/config/manifest.js`.

          //= link application.css

        and restart your server
            app/views/layouts/application.html.erb:10
            test/controllers/sessions_controller_test.rb:6:in `block in <class:SessionsControllerTest>'

67 tests, 130 assertions, 0 failures, 20 errors, 0 skips
```