### PR TITLE
fix: Pin yarn to 1.22.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
   - sudo apt-get -y install graphviz
   - nvm install 14.18.1
   - npm install -g yarn@1.22.10
+  # installing yarn 1.22.10 installed 3.2.1! After the installation,
+  # pin yarn to a specific version.
+  - yarn set version 1.22.10
   - yarn install
 
 install:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,1 @@
-yarnPath: .yarn/releases/yarn-3.2.1.cjs
+yarnPath: .yarn/releases/yarn-1.22.10.cjs


### PR DESCRIPTION
The command `npm install -g yarn@1.22.10` installs yarn `3.2.1`.  As a result, many webpack calls fail because 3.2.1 is missing parameters expected by webpack.

This is shown in https://app.travis-ci.com/github/land-of-apps/sample_app_6th_ed/builds/254733847

To fix it run an additional command that selects yarn 1.22.10.